### PR TITLE
Support NFT as a governance token

### DIFF
--- a/contracts/dao-contract/src/DAOContract.cs
+++ b/contracts/dao-contract/src/DAOContract.cs
@@ -93,7 +93,8 @@ public partial class DAOContract : DAOContractContainer.DAOContractBase
                 VoteContractAddress = State.VoteContract.Value
             },
             IsNetworkDao = input.IsNetworkDao,
-            GovernanceMechanism = (GovernanceMechanism)input.GovernanceMechanism
+            GovernanceMechanism = (GovernanceMechanism)input.GovernanceMechanism,
+            ProposalThreshold = input.ProposalThreshold
         };
 
         State.DAOInfoMap[daoId] = daoInfo;

--- a/contracts/dao-contract/src/DAOContractConstants.cs
+++ b/contracts/dao-contract/src/DAOContractConstants.cs
@@ -13,7 +13,8 @@ public static class DAOContractConstants
     public const int SocialMediaUrlMaxLength = 64;
 
     // governance token
-    public const int SymbolMaxLength = 10;
+    public const char NFTSymbolSeparator = '-';
+    public const string CollectionSymbolSuffix = "0";
 
     // file
     public const int FileMaxCount = 20;

--- a/contracts/dao-contract/src/DAOContract_Helper.cs
+++ b/contracts/dao-contract/src/DAOContract_Helper.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text.RegularExpressions;
 using AElf;
 using AElf.Contracts.MultiToken;
 using AElf.Types;
@@ -44,15 +45,31 @@ public partial class DAOContract
         CheckDaoSubsistStatus(input);
     }
 
-    private bool IsValidTokenChar(char character)
+    private bool IsValidTokenChar(char c)
     {
-        return character >= 'A' && character <= 'Z';
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+    }
+    
+    private bool IsValidItemId(char c)
+    {
+        return c >= '0' && c <= '9';
     }
     
     private TokenInfo AssertToken(string token)
     {
+        //token
         Assert(!string.IsNullOrEmpty(token), "Token is null.");
-        Assert(token!.Length <= DAOContractConstants.SymbolMaxLength && token.All(IsValidTokenChar), "Invalid token symbol.");
+        var words = token!.Split(DAOContractConstants.NFTSymbolSeparator);
+        Assert(words[0].Length > 0 && words[0].All(IsValidTokenChar), "Invalid Symbol input");
+        
+        //NFT
+        if (words.Length > 1)
+        {
+            Assert(words.Length == 2 && words[1].Length > 0 && words[1].All(IsValidItemId), "Invalid NFT Symbol input");
+            //cannot be an NFT Collection
+            Assert(words[1] != DAOContractConstants.CollectionSymbolSuffix, "NFT Collection is not supported.");
+        }
+        
         var tokenInfo = State.TokenContract.GetTokenInfo.Call(new GetTokenInfoInput
         {
             Symbol = token

--- a/contracts/dao-contract/src/DAOContract_Helper.cs
+++ b/contracts/dao-contract/src/DAOContract_Helper.cs
@@ -87,7 +87,6 @@ public partial class DAOContract
             MinimalApproveThreshold = input.MinimalApproveThreshold,
             MaximalAbstentionThreshold = input.MaximalAbstentionThreshold,
             MaximalRejectionThreshold = input.MaximalRejectionThreshold,
-            ProposalThreshold = input.ProposalThreshold
         };
     }
     

--- a/contracts/dao-contract/src/DAOContract_HighCouncil.cs
+++ b/contracts/dao-contract/src/DAOContract_HighCouncil.cs
@@ -75,12 +75,16 @@ public partial class DAOContract
 
     private void ProcessEnableHighCouncil(Hash daoId, HighCouncilInput highCouncilInput)
     {
-        HighCouncilConfig highCouncilConfig = highCouncilInput.HighCouncilConfig;
-        GovernanceSchemeThreshold threshold = highCouncilInput.GovernanceSchemeThreshold;
+        var daoInfo = State.DAOInfoMap[daoId];
+        Assert(daoInfo != null, "Dao information not found.");
+        
+        var highCouncilConfig = highCouncilInput.HighCouncilConfig;
+        var threshold = highCouncilInput.GovernanceSchemeThreshold;
 
         State.HighCouncilEnabledStatusMap[daoId] = true;
 
         var governanceSchemeThreshold = ConvertToGovernanceSchemeThreshold(threshold);
+        governanceSchemeThreshold.ProposalThreshold = daoInfo!.ProposalThreshold;
 
         State.GovernanceContract.AddGovernanceScheme.Send(new AddGovernanceSchemeInput
         {

--- a/contracts/dao-contract/src/Protobuf/contract/dao_contract.proto
+++ b/contracts/dao-contract/src/Protobuf/contract/dao_contract.proto
@@ -80,6 +80,7 @@ message CreateDAOInput {
   bool is_treasury_needed = 7;  // if true, create treasury
   repeated File files = 8;
   bool is_network_dao = 9;
+  int64 proposal_threshold = 10;
 }
 
 message HighCouncilInput {
@@ -106,7 +107,6 @@ message GovernanceSchemeThreshold {// copy from governance contract
   int64 minimal_approve_threshold = 3;     // percentage
   int64 maximal_rejection_threshold = 4;   // percentage
   int64 maximal_abstention_threshold = 5;  // percentage
-  int64 proposal_threshold = 6;
 }
 
 message HighCouncilConfig {
@@ -161,6 +161,7 @@ message DAOInfo {
   ContractAddressList contract_address_list = 5;
   bool is_network_dao = 6;
   GovernanceMechanism governance_mechanism = 7;
+  int64 proposal_threshold = 8;
 }
 
 message ContractAddressList {
@@ -227,6 +228,7 @@ message RemoveGovernanceSchemeInput {
 message SetGovernanceTokenInput {
   aelf.Hash dao_id = 1;
   string governance_token = 2;
+  int64 proposal_threshold = 3;
 }
 
 message SetProposalTimePeriodInput {

--- a/contracts/dao-contract/src/TomorrowDAO.Contracts.DAO.csproj
+++ b/contracts/dao-contract/src/TomorrowDAO.Contracts.DAO.csproj
@@ -16,7 +16,6 @@
     </Target>
 
     <ItemGroup>
-        <PackageReference Include="AElf.Contracts.MultiToken" Version="1.6.0" />
         <PackageReference Include="AElf.Sdk.CSharp" Version="1.6.0" />
         <PackageReference Include="AElf.Tools" Version="1.0.2">
             <PrivateAssets>all</PrivateAssets>

--- a/contracts/dao-contract/src/TomorrowDAO.Contracts.DAO.csproj
+++ b/contracts/dao-contract/src/TomorrowDAO.Contracts.DAO.csproj
@@ -16,6 +16,7 @@
     </Target>
 
     <ItemGroup>
+        <PackageReference Include="AElf.Contracts.MultiToken" Version="1.6.0" />
         <PackageReference Include="AElf.Sdk.CSharp" Version="1.6.0" />
         <PackageReference Include="AElf.Tools" Version="1.0.2">
             <PrivateAssets>all</PrivateAssets>

--- a/contracts/dao-contract/test/DAOContractTests.cs
+++ b/contracts/dao-contract/test/DAOContractTests.cs
@@ -437,10 +437,10 @@ public partial class DAOContractTests : DAOContractTestBase
     }
 
     [Theory]
-    [InlineData("ABCdE", "Invalid token symbol.")]
-    [InlineData("ABCDEFGHIJK", "Invalid token symbol.")]
+    [InlineData("ABCdE", "Token not found.")]
+    [InlineData("ABCDEFGHIJK", "Token not found.")]
     [InlineData("TEST", "Token not found.")]
-    [InlineData("ELF-1", "Invalid token symbol.")]
+    [InlineData("ELF-1", "Token not found.")]
     public async Task CreateDAOTests_GovernanceToken_Fail(string symbol, string errorMessage)
     {
         await InitializeAsync();

--- a/contracts/dao-contract/test/Protobuf/stub/dao_contract.proto
+++ b/contracts/dao-contract/test/Protobuf/stub/dao_contract.proto
@@ -80,6 +80,7 @@ message CreateDAOInput {
   bool is_treasury_needed = 7;  // if true, create treasury
   repeated File files = 8;
   bool is_network_dao = 9;
+  int64 proposal_threshold = 10;
 }
 
 message HighCouncilInput {
@@ -106,7 +107,6 @@ message GovernanceSchemeThreshold {// copy from governance contract
   int64 minimal_approve_threshold = 3;     // percentage
   int64 maximal_rejection_threshold = 4;   // percentage
   int64 maximal_abstention_threshold = 5;  // percentage
-  int64 proposal_threshold = 6;
 }
 
 message HighCouncilConfig {
@@ -161,6 +161,7 @@ message DAOInfo {
   ContractAddressList contract_address_list = 5;
   bool is_network_dao = 6;
   GovernanceMechanism governance_mechanism = 7;
+  int64 proposal_threshold = 8;
 }
 
 message ContractAddressList {
@@ -227,6 +228,7 @@ message RemoveGovernanceSchemeInput {
 message SetGovernanceTokenInput {
   aelf.Hash dao_id = 1;
   string governance_token = 2;
+  int64 proposal_threshold = 3;
 }
 
 message SetProposalTimePeriodInput {

--- a/contracts/governance-contract/src/Protobuf/reference/dao_contract.proto
+++ b/contracts/governance-contract/src/Protobuf/reference/dao_contract.proto
@@ -30,6 +30,8 @@ service DAOContract {
   rpc EnableHighCouncil (EnableHighCouncilInput) returns (google.protobuf.Empty) {}
   rpc DisableHighCouncil (aelf.Hash) returns (google.protobuf.Empty) {}
   rpc GetHighCouncilStatus (aelf.Hash) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
+  rpc AddHighCouncilMembers (AddHighCouncilMembersInput) returns (google.protobuf.Empty) {}
+  rpc RemoveHighCouncilMembers (RemoveHighCouncilMembersInput) returns (google.protobuf.Empty) {}
 
   // file
   rpc UploadFileInfos (UploadFileInfosInput) returns (google.protobuf.Empty) {}
@@ -57,7 +59,7 @@ service DAOContract {
   rpc AddMember (AddMemberInput) returns (google.protobuf.Empty) {}
   rpc RemoveMember (RemoveMemberInput) returns (google.protobuf.Empty) {}
   rpc GetIsMember (GetIsMemberInput) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
-  rpc GetMemberCount (aelf.Hash) returns (google.protobuf.Int32Value) {option (aelf.is_view) = true;}
+  rpc GetMemberCount (aelf.Hash) returns (google.protobuf.Int64Value) {option (aelf.is_view) = true;}
 }
 
 message InitializeInput {
@@ -78,11 +80,14 @@ message CreateDAOInput {
   bool is_treasury_needed = 7;  // if true, create treasury
   repeated File files = 8;
   bool is_network_dao = 9;
+  int64 proposal_threshold = 10;
 }
 
 message HighCouncilInput {
   HighCouncilConfig high_council_config = 1;  // empty if high council is not enabled
   GovernanceSchemeThreshold governance_scheme_threshold = 2;  // governance scheme threshold for high council
+  AddressList high_council_members = 3;
+  bool is_high_council_election_close = 4;
 }
 
 message Metadata {
@@ -102,7 +107,6 @@ message GovernanceSchemeThreshold {// copy from governance contract
   int64 minimal_approve_threshold = 3;     // percentage
   int64 maximal_rejection_threshold = 4;   // percentage
   int64 maximal_abstention_threshold = 5;  // percentage
-  int64 proposal_threshold = 6;
 }
 
 message HighCouncilConfig {
@@ -157,6 +161,7 @@ message DAOInfo {
   ContractAddressList contract_address_list = 5;
   bool is_network_dao = 6;
   GovernanceMechanism governance_mechanism = 7;
+  int64 proposal_threshold = 8;
 }
 
 message ContractAddressList {
@@ -223,6 +228,7 @@ message RemoveGovernanceSchemeInput {
 message SetGovernanceTokenInput {
   aelf.Hash dao_id = 1;
   string governance_token = 2;
+  int64 proposal_threshold = 3;
 }
 
 message SetProposalTimePeriodInput {
@@ -251,6 +257,16 @@ message DaoProposalTimePeriod {
   int64 pending_time_period = 3; //day
   int64 execute_time_period = 4; //day
   int64 veto_execute_time_period = 5; //day
+}
+
+message AddHighCouncilMembersInput {
+  aelf.Hash dao_id = 1;
+  AddressList add_high_councils = 2;
+}
+
+message RemoveHighCouncilMembersInput {
+  aelf.Hash dao_id = 1;
+  AddressList remove_high_councils = 2;
 }
 
 // log event

--- a/contracts/governance-contract/test/Protobuf/stub/dao_contract.proto
+++ b/contracts/governance-contract/test/Protobuf/stub/dao_contract.proto
@@ -30,6 +30,8 @@ service DAOContract {
   rpc EnableHighCouncil (EnableHighCouncilInput) returns (google.protobuf.Empty) {}
   rpc DisableHighCouncil (aelf.Hash) returns (google.protobuf.Empty) {}
   rpc GetHighCouncilStatus (aelf.Hash) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
+  rpc AddHighCouncilMembers (AddHighCouncilMembersInput) returns (google.protobuf.Empty) {}
+  rpc RemoveHighCouncilMembers (RemoveHighCouncilMembersInput) returns (google.protobuf.Empty) {}
 
   // file
   rpc UploadFileInfos (UploadFileInfosInput) returns (google.protobuf.Empty) {}
@@ -78,11 +80,14 @@ message CreateDAOInput {
   bool is_treasury_needed = 7;  // if true, create treasury
   repeated File files = 8;
   bool is_network_dao = 9;
+  int64 proposal_threshold = 10;
 }
 
 message HighCouncilInput {
   HighCouncilConfig high_council_config = 1;  // empty if high council is not enabled
   GovernanceSchemeThreshold governance_scheme_threshold = 2;  // governance scheme threshold for high council
+  AddressList high_council_members = 3;
+  bool is_high_council_election_close = 4;
 }
 
 message Metadata {
@@ -102,7 +107,6 @@ message GovernanceSchemeThreshold {// copy from governance contract
   int64 minimal_approve_threshold = 3;     // percentage
   int64 maximal_rejection_threshold = 4;   // percentage
   int64 maximal_abstention_threshold = 5;  // percentage
-  int64 proposal_threshold = 6;
 }
 
 message HighCouncilConfig {
@@ -157,6 +161,7 @@ message DAOInfo {
   ContractAddressList contract_address_list = 5;
   bool is_network_dao = 6;
   GovernanceMechanism governance_mechanism = 7;
+  int64 proposal_threshold = 8;
 }
 
 message ContractAddressList {
@@ -223,6 +228,7 @@ message RemoveGovernanceSchemeInput {
 message SetGovernanceTokenInput {
   aelf.Hash dao_id = 1;
   string governance_token = 2;
+  int64 proposal_threshold = 3;
 }
 
 message SetProposalTimePeriodInput {
@@ -251,6 +257,16 @@ message DaoProposalTimePeriod {
   int64 pending_time_period = 3; //day
   int64 execute_time_period = 4; //day
   int64 veto_execute_time_period = 5; //day
+}
+
+message AddHighCouncilMembersInput {
+  aelf.Hash dao_id = 1;
+  AddressList add_high_councils = 2;
+}
+
+message RemoveHighCouncilMembersInput {
+  aelf.Hash dao_id = 1;
+  AddressList remove_high_councils = 2;
 }
 
 // log event


### PR DESCRIPTION
1. Modify the DAO contract governance token verification logic to support NFT symbols.
2. Fix the threshold issue of the proposal. close #19 